### PR TITLE
fix(transparent) avoid redefinition of kernel ipv6 definitions

### DIFF
--- a/patches/1.13.6.2/nginx-1.13.6_02-listen-transparent.patch
+++ b/patches/1.13.6.2/nginx-1.13.6_02-listen-transparent.patch
@@ -236,8 +236,16 @@ diff -ru a/nginx-1.13.6/auto/os/linux b/nginx-1.13.6/auto/os/linux
 diff -ru a/nginx-1.13.6/src/os/unix/ngx_linux_config.h b/nginx-1.13.6/src/os/unix/ngx_linux_config.h
 --- a/nginx-1.13.6/src/os/unix/ngx_linux_config.h	2018-10-31 12:26:52.689485871 -0300
 +++ b/nginx-1.13.6/src/os/unix/ngx_linux_config.h	2018-10-31 12:26:55.439485758 -0300
-@@ -117,6 +117,11 @@
- #define ngx_debug_init()
+@@ -42,7 +42,6 @@
+ #include <sched.h>
+ 
+ #include <sys/socket.h>
+-#include <netinet/in.h>
+ #include <netinet/tcp.h>        /* TCP_NODELAY, TCP_CORK */
+ #include <arpa/inet.h>
+ #include <netdb.h>
+@@ -61,6 +60,14 @@
+ #include <ngx_auto_config.h>
  
  
 +#if (NGX_HAVE_IPV6_TRANSPARENT)
@@ -245,6 +253,10 @@ diff -ru a/nginx-1.13.6/src/os/unix/ngx_linux_config.h b/nginx-1.13.6/src/os/uni
 +#endif
 +
 +
- extern char **environ;
- 
- 
++#include <netinet/in.h>
++
++
+ #if (NGX_HAVE_POSIX_SEM)
+ #include <semaphore.h>
+ #endif
+


### PR DESCRIPTION
The following errors occur when building on Debian 7:
```
docker: In file included from src/os/unix/ngx_linux_config.h:121:0,
    docker:                  from src/core/ngx_config.h:26,
    docker:                  from src/core/ngx_log.c:8:
    docker: /usr/include/linux/in6.h:30:8: error: redefinition of 'struct in6_addr'
    docker: In file included from src/os/unix/ngx_linux_config.h:45:0,
    docker:                  from src/core/ngx_config.h:26,
    docker:                  from src/core/ngx_log.c:8:
    docker: /usr/include/netinet/in.h:198:8: note: originally defined here
    docker: In file included from src/os/unix/ngx_linux_config.h:121:0,
    docker:                  from src/core/ngx_config.h:26,
    docker:                  from src/core/ngx_log.c:8:
    docker: /usr/include/linux/in6.h:46:8: error: redefinition of 'struct sockaddr_in6'
    docker: In file included from src/os/unix/ngx_linux_config.h:44:0,
    docker:                  from src/core/ngx_config.h:26,
    docker:                  from src/core/ngx_log.c:8:
    docker: /usr/include/x86_64-linux-gnu/sys/socket.h:92:17: note: originally defined here
    docker: In file included from src/os/unix/ngx_linux_config.h:121:0,
    docker:                  from src/core/ngx_config.h:26,
```

We must include `linux/in6.h` before `netinet/in.h`, since the latter
maintains definition guards around the IPv6 kernel structures:

https://code.woboq.org/userspace/glibc/inet/netinet/in.h.html#209

